### PR TITLE
Fix barrier counting for self-referential nodes

### DIFF
--- a/src/flowno/core/node_base.py
+++ b/src/flowno/core/node_base.py
@@ -534,8 +534,11 @@ class FinalizedNode(Generic[Unpack[_Ts], ReturnTupleT_co]):
                     # Skip this input port if it is not connected.
                     if consumer_input.connected_output is None:
                         continue
-                    # Check that this input port is connected to self.
-                    if consumer_input.connected_output.node is self:
+                    # Check that this input port is connected specifically to the current output port.
+                    if (
+                        consumer_input.connected_output.node is self
+                        and consumer_input.connected_output.port_index == output_port
+                    ):
                         # Check if this input port expects data at the specified run level.
                         if consumer_input.minimum_run_level == run_level:
                             ret.append(consumer_input)


### PR DESCRIPTION
Fixes #22 

## Summary
- handle `get_output_nodes_by_run_level` correctly when multiple outputs feed the same node
- fix event-loop hang when Swap node cycles past generation 0

## Testing
- `pytest -k simple_swapper_cycle -vv`

------
https://chatgpt.com/codex/tasks/task_e_6840cfbeed348331a8a60b44cd474c75