### PR TITLE
Fix FlowHDL initialization and update magic tests

### DIFF
--- a/src/flowno/core/flow_hdl.py
+++ b/src/flowno/core/flow_hdl.py
@@ -54,25 +54,23 @@ logger = logging.getLogger(__name__)
 
 
 class FlowHDL(FlowHDLView):
-    """Context manager for building dataflow graphs.
+    """Context manager for constructing and executing dataflow graphs.
 
-    The FlowHDL context allows:
+    ``FlowHDL`` extends :class:`FlowHDLView` with the ability to run the
+    resulting :class:`~flowno.core.flow.flow.Flow`.  Within the ``with`` block
+    users may assign draft nodes to attributes and reference not-yet-defined
+    nodes freely.  When the context exits, all placeholders are resolved and the
+    underlying :class:`Flow` is finalized.
 
-    - Assigning nodes as attributes
-    - Forward-referencing nodes that haven't been defined yet
-    - Automatic resolution of placeholder references when exiting the context
-
-    Attributes within the context become nodes in the final flow. The context
-    automatically finalizes all node connections when exited.
-
-    Use the special syntax:
-
+    Example
+    -------
     >>> with FlowHDL() as f:
-    ...     f.node1 = Node1(f.node2)
-    ...     f.node2 = Node2()
+    ...     f.result = Add(f.a, f.b)
+    ...     f.a = Source(1)
+    ...     f.b = Source(2)
     >>> f.run_until_complete()
 
-    User defined attributes should not start with an underscore.
+    User defined attribute names should not start with an underscore.
 
     :canonical: :py:class:`flowno.core.flow_hdl.FlowHDL`
     """
@@ -81,6 +79,7 @@ class FlowHDL(FlowHDLView):
     """Keywords that should not be treated as nodes in the graph."""
 
     def __init__(self) -> None:
+        super().__init__()
         self._flow: Flow = Flow(is_finalized=False)
     
     @override

--- a/src/flowno/core/flow_hdl_view.py
+++ b/src/flowno/core/flow_hdl_view.py
@@ -16,7 +16,15 @@ from typing_extensions import Self, TypeVarTuple, Unpack, override
 logger = logging.getLogger(__name__)
 
 class FlowHDLView:
-    """The parent class for FlowHDL context.
+    """Base implementation of the :class:`FlowHDL` attribute protocol.
+
+    ``FlowHDLView`` acts like a simple namespace for draft nodes.  Public
+    attribute assignments are stored in ``self._nodes`` while private names
+    (those starting with ``_``) behave like normal Python attributes.  Accessing
+    an undefined public attribute before the view is finalized returns a
+    :class:`~flowno.core.node_base.NodePlaceholder` so that connections can be
+    declared before the target node is defined.  Once finalized, attribute
+    lookups behave normally and missing attributes raise :class:`AttributeError`.
     """
 
     _is_finalized: bool

--- a/src/flowno/core/node_base.py
+++ b/src/flowno/core/node_base.py
@@ -244,8 +244,12 @@ class DraftNode(ABC, Generic[Unpack[_Ts], ReturnTupleT_co]):
             list[DraftNode[Unpack[tuple[object, ...]], tuple[object, ...]]],
         ] = defaultdict(list)
 
-        minimum_run_level = self._minimum_run_level or [0] * len(args)
-        for input_port_index in (InputPortIndex(index) for index in range(len(args))):
+        max_ports = max(len(args), len(self._minimum_run_level))
+        if self._minimum_run_level:
+            minimum_run_level = list(self._minimum_run_level) + [0] * (max_ports - len(self._minimum_run_level))
+        else:
+            minimum_run_level = [0] * max_ports
+        for input_port_index in (InputPortIndex(index) for index in range(max_ports)):
             self._input_ports[input_port_index].minimum_run_level = minimum_run_level[input_port_index]
 
         # loop over each argument and set up the corresponding input port


### PR DESCRIPTION
## Summary
- call `FlowHDLView.__init__` from `FlowHDL.__init__`
- clarify FlowHDL and FlowHDLView docstrings
- create missing input ports for unused parameters in `DraftNode`
- fix and clean tests for FlowHDL magic attribute behavior

## Testing
- `pytest -q tests/test_flowhdl_view_magic.py`

------
https://chatgpt.com/codex/tasks/task_e_684103067a5c8331a1d8d3dec90d0a11