### PR TITLE
Fix event loop return value

### DIFF
--- a/src/flowno/core/event_loop/event_loop.py
+++ b/src/flowno/core/event_loop/event_loop.py
@@ -605,6 +605,7 @@ class EventLoop:
         except:
             self._uninstall_signal_handlers()
             raise
+        return return_value
 
     def _run_event_loop_core(
         self,


### PR DESCRIPTION
## Summary
- return the computed result in `EventLoop.run_until_complete`

## Testing
- `pytest tests/test_event_loop.py::test_queue_spsc tests/test_event_loop.py::test_queue_mpsc -q`

------
https://chatgpt.com/codex/tasks/task_e_68410710938c83318fca74dd9c5dc6b1