### PR TITLE
Add experimental group node templates

### DIFF
--- a/src/flowno/__init__.py
+++ b/src/flowno/__init__.py
@@ -28,6 +28,7 @@ from .core.event_loop.selectors import SocketHandle
 from .core.flow.flow import Flow, TerminateLimitReached
 from .core.flow_hdl import FlowHDL
 from .core.node_base import DraftNode, Stream
+from .core.group_node import DraftGroupNode
 from .decorators import node
 
 try:
@@ -93,6 +94,7 @@ __all__ = [
     "socket",
     "nodes",
     "DraftNode",
+    "DraftGroupNode",
     "Stream",
     "SocketHandle",
     "FlowHDL",

--- a/src/flowno/core/flow_hdl_view.py
+++ b/src/flowno/core/flow_hdl_view.py
@@ -11,6 +11,7 @@ from flowno.core.node_base import (
     NodePlaceholder,
     OutputPortRefPlaceholder,
 )
+from flowno.core.group_node import DraftGroupNode
 from typing_extensions import Self, TypeVarTuple, Unpack, override
 from collections import OrderedDict
 
@@ -120,6 +121,10 @@ class FlowHDLView:
                 within this "layer" of the FlowHDL context.
         """
         logger.info("Finalizing FlowHDL")
+
+        for dn in draft_nodes:
+            if isinstance(dn, DraftGroupNode):
+                dn.debug_dummy()
 
         finalized_nodes: dict[
             DraftNode[Unpack[tuple[object, ...]], tuple[object, ...]],

--- a/src/flowno/core/group_node.py
+++ b/src/flowno/core/group_node.py
@@ -1,0 +1,42 @@
+import logging
+from typing import Any, ClassVar, TYPE_CHECKING
+
+from typing_extensions import TypeVarTuple, Unpack, override
+
+from .node_base import DraftNode, OriginalCall
+
+if TYPE_CHECKING:
+    from .flow_hdl_view import FlowHDLView
+
+logger = logging.getLogger(__name__)
+
+_Ts = TypeVarTuple("_Ts")
+_ReturnTupleT_co = tuple[Any, ...]
+
+
+class DraftGroupNode(DraftNode[Unpack[_Ts], tuple[Any, ...]]):
+    """Minimal draft group node used for experimenting with template groups."""
+
+    original_func: ClassVar[Any]
+    _sub_view: 'FlowHDLView'
+    _return_node: DraftNode
+
+    @override
+    def __init__(self, *args: Unpack[tuple[Any, ...]]):
+        print(f"[DEBUG] instantiate group {self.__class__.__name__}")
+        super().__init__(*args)
+        from .flow_hdl_view import FlowHDLView
+
+        parent = next(reversed(FlowHDLView.contextStack))
+        with FlowHDLView() as sub_view:
+            sub_view._flow = getattr(parent, "_flow", None)  # type: ignore[attr-defined]
+            self._return_node = self.__class__.original_func(sub_view, *args)
+        self._sub_view = sub_view
+
+    async def call(self, *args: Unpack[_Ts]):  # type: ignore[override]
+        raise RuntimeError("Group nodes do not run")
+
+    def debug_dummy(self) -> None:
+        print(
+            f"[DEBUG] finalize group {self.__class__.__name__} with sub nodes {list(self._sub_view._nodes.keys())}"
+        )

--- a/src/flowno/decorators/node.py
+++ b/src/flowno/decorators/node.py
@@ -45,7 +45,7 @@ Examples:
 
 from collections.abc import AsyncGenerator, Callable, Coroutine
 from typing_extensions import Unpack
-from typing import Any, Final, Literal, TypeVar, Union, overload
+from typing import Any, Final, Literal, TypeVar, Union, overload, ClassVar
 
 from flowno.core.mono_node import (
     MonoNode,
@@ -55,7 +55,7 @@ from flowno.core.mono_node import (
     MonoNode1,
     MonoNode2,
 )
-from flowno.core.node_base import DraftNode
+from flowno.core.node_base import DraftNode, OriginalCall
 from flowno.core.streaming_node import (
     StreamingNode,
     StreamingNode0,
@@ -310,3 +310,37 @@ def node(
         return node_meta_single_dec(stream_in=stream_in)
     else:
         return node_meta_multiple_dec(stream_in=stream_in)
+from inspect import signature, Parameter
+from flowno.core.group_node import DraftGroupNode
+
+
+def create_func_group_node_subclass(func: Callable[..., DraftNode]) -> type[DraftGroupNode]:
+    print(f"[DEBUG] define template group {func.__name__}")
+    func_sig = signature(func)
+    params = list(func_sig.parameters.values())[1:]  # drop FlowHDLView parameter
+    default_values: dict[int, object] = {}
+    for idx, p in enumerate(params):
+        if p.default is not Parameter.empty:
+            default_values[idx] = p.default
+
+    class DynamicGroupNode(DraftGroupNode):
+        _minimum_run_level: ClassVar[list[int]] = []
+        _default_values: ClassVar[dict[int, object]] = default_values
+        _original_call = OriginalCall(
+            call_signature=func_sig,
+            call_code=func.__code__,
+            func_name=func.__name__,
+            class_name=None,
+        )
+        original_func = staticmethod(func)
+
+    DynamicGroupNode.__name__ = func.__name__
+    return DynamicGroupNode
+
+
+def template(func: Callable[..., DraftNode]) -> type[DraftGroupNode]:
+    return create_func_group_node_subclass(func)
+
+
+# expose attribute so users can write @node.template
+node.template = template


### PR DESCRIPTION
## Summary
- add minimal `DraftGroupNode` class for template groups
- allow `@node.template` decorator for sync group functions
- debug hooks in `FlowHDLView._finalize` to show group info

## Testing
- `pytest -m "not network" -q`

------
https://chatgpt.com/codex/tasks/task_e_6843774b10988331820677e505b2d0bb