### PR TITLE
Fix FlowHDLView context result propagation

### DIFF
--- a/src/flowno/core/flow_hdl.py
+++ b/src/flowno/core/flow_hdl.py
@@ -75,7 +75,12 @@ class FlowHDL(FlowHDLView):
     :canonical: :py:class:`flowno.core.flow_hdl.FlowHDL`
     """
 
-    KEYWORDS: ClassVar[list[str]] = ["KEYWORDS", "run_until_complete", "create_task"]
+    KEYWORDS: ClassVar[list[str]] = [
+        "KEYWORDS",
+        "run_until_complete",
+        "create_task",
+        "register_child_result",
+    ]
     """Keywords that should not be treated as nodes in the graph."""
 
     def __init__(self) -> None:

--- a/src/flowno/core/flow_hdl_view.py
+++ b/src/flowno/core/flow_hdl_view.py
@@ -37,7 +37,7 @@ class FlowHDLView:
 
     _is_finalized: bool
 
-    KEYWORDS: ClassVar[list[str]] = []
+    KEYWORDS: ClassVar[list[str]] = ["register_child_result"]
 
     contextStack: ClassVar[OrderedDict[Self, list[DraftNode]]] = OrderedDict()
 


### PR DESCRIPTION
## Summary
- ensure `register_child_result` is not treated as a graph node
- add the keyword to `FlowHDL` and `FlowHDLView`

## Testing
- `pytest -m "not network"`

------
https://chatgpt.com/codex/tasks/task_e_6844ae1693588331a11e180289cb4a08