### PR TITLE
Enable proposed group syntax tests

### DIFF
--- a/tests/test_proposed_group_syntax.py
+++ b/tests/test_proposed_group_syntax.py
@@ -24,7 +24,7 @@ def test_triple_product_group_node():
         f.result = TripleProduct(2, 3, 4)
 
     f.run_until_complete()
-    assert f.result.output() == 26
+    assert f.result.get_data() == (26,)
 
 
 def test_increment_group_node():


### PR DESCRIPTION
## Summary
- unskip `test_triple_product_group_node` and `test_increment_group_node`

## Testing
- `pytest -m "not network" -q` *(fails: test_queue_mpmc, test_triple_product_group_node)*

------
https://chatgpt.com/codex/tasks/task_e_6847348559808331b526834306168a72