### PR TITLE
Improve docs deploy workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -65,7 +65,7 @@ jobs:
     name: Deploy Documentation Package
     runs-on: ubuntu-latest
     needs: docs_build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -156,8 +156,3 @@ Python's `__getattr__` method. However, this approach enables:
 ## License
 
 Flowno is released under the MIT License.
-
-## Documentation Deployment
-
-The CI/CD workflow builds and deploys the documentation whenever a commit is pushed to `main`. To redeploy manually, open the **Actions** tab on GitHub, select the `CI/CD` workflow, and use the **Run workflow** button. Choose the branch you want to deploy (usually `main`) and start the run. The workflow's `docs_deploy` job will execute because the manual trigger uses the `workflow_dispatch` event.
-

--- a/README.md
+++ b/README.md
@@ -156,3 +156,8 @@ Python's `__getattr__` method. However, this approach enables:
 ## License
 
 Flowno is released under the MIT License.
+
+## Documentation Deployment
+
+The CI/CD workflow builds and deploys the documentation whenever a commit is pushed to `main`. To redeploy manually, open the **Actions** tab on GitHub, select the `CI/CD` workflow, and use the **Run workflow** button. Choose the branch you want to deploy (usually `main`) and start the run. The workflow's `docs_deploy` job will execute because the manual trigger uses the `workflow_dispatch` event.
+


### PR DESCRIPTION
## Summary
- allow manual documentation deploys via `workflow_dispatch`
- document manual docs deployment process

## Testing
- `pytest -m "not network"` *(fails: tests/test_flow_event_loop.py::test_sleep)*

------
https://chatgpt.com/codex/tasks/task_e_68475768634c8331bed5dd7f8af78268