### PR TITLE
Fix group conditional wiring

### DIFF
--- a/src/flowno/core/group_node.py
+++ b/src/flowno/core/group_node.py
@@ -52,3 +52,56 @@ class DraftGroupNode(DraftNode[Unpack[_Ts], tuple[Any, ...]]):
         logger.debug(
             f"finalize group {self.__class__.__name__} with sub nodes {self._debug_context_nodes} and return node {self._return_node}"
         )
+
+    def if_(self, predicate: object) -> "DraftGroupNode":
+        """Wrap this group with a :class:`PropagateIf` node.
+
+        The conditional node is inserted *after* the group's return node so the
+        entire group executes but its output is gated by ``predicate``. Any
+        existing consumers of this group are rewired to consume the conditional
+        output.
+        """
+
+        from .flow_hdl_view import FlowHDLView
+        from flowno.decorators import node
+        from .node_base import DraftInputPortRef, DraftOutputPortRef
+        from .types import InputPortIndex, OutputPortIndex
+        from .node_base import PropagateIf
+
+        # Capture existing downstream connections so they can be rewired to the
+        # conditional group after creation.
+        downstream: list[tuple[DraftNode, InputPortIndex]] = []
+        for out_idx, consumers in list(self._connected_output_nodes.items()):
+            for consumer in list(consumers):
+                for in_idx, port in consumer._input_ports.items():
+                    conn = port.connected_output
+                    if (
+                        isinstance(conn, DraftOutputPortRef)
+                        and conn.node is self
+                        and conn.port_index == OutputPortIndex(out_idx)
+                    ):
+                        downstream.append((consumer, InputPortIndex(in_idx)))
+                        try:
+                            self._connected_output_nodes[OutputPortIndex(out_idx)].remove(consumer)
+                        except (KeyError, ValueError):
+                            pass
+                        port.connected_output = None
+
+        @node.template(capture=[self])
+        def _IfGroup(f: FlowHDLView, pred: object) -> DraftNode:
+            return PropagateIf(pred, self)
+
+        if FlowHDLView.contextStack:
+            ctx = next(reversed(FlowHDLView.contextStack))
+            try:
+                FlowHDLView.contextStack[ctx].remove(self)
+            except ValueError:
+                pass
+
+        conditional_group = _IfGroup(predicate)
+
+        # Reconnect previous consumers to the conditional group's output
+        for consumer, idx in downstream:
+            conditional_group.output(0).connect(DraftInputPortRef(consumer, idx))
+
+        return conditional_group

--- a/tests/test_conditional_groups.py
+++ b/tests/test_conditional_groups.py
@@ -88,3 +88,12 @@ def test_nested_group_if_false():
         f.b = OuterGroup(1).if_(False)
     f.run_until_complete()
     assert f.b.get_data() is None
+
+
+def test_group_if_rewires_consumers():
+    with FlowHDL() as f:
+        g = MyGroup(1)
+        f.c = Inc(g)
+        f.result = g.if_(True)
+    f.run_until_complete()
+    assert f.c._input_ports[0].connected_output.node is f.result


### PR DESCRIPTION
## Summary
- override `DraftGroupNode.if_` to insert a `PropagateIf` node after the group's return node
- rewire downstream consumers to use the conditional group's output
- test that consumers are correctly rewired

## Testing
- `pytest -m "not network" -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b9b6f80c8331a5f933e568a49530