### PR TITLE
Update docs for conditional nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ or, for cyclic flows, until an uncaught exception occurs.
 
 ## Features TODO
 
-- **Conditional Nodes**  
-  Currently all nodes are executed unconditionally. The only way to skip a node is to add an immediate return statement to bypass the node's logic. I plan to add a way to conditionally execute nodes based on the output of other nodes.
+There are currently no planned features.
 
 ## Non-Goals
 

--- a/docs/source/developer_guide/conditional_nodes.rst
+++ b/docs/source/developer_guide/conditional_nodes.rst
@@ -1,0 +1,11 @@
+Conditional Nodes
+=================
+
+The class :class:`~flowno.core.node_base.PropagateIf` passes through its input
+only when a predicate is truthy. Draft nodes have a convenience method
+:meth:`~flowno.core.node_base.DraftNode.if_` to insert ``PropagateIf`` before a
+node and reconnect existing edges. Groups expose the same helper via
+:meth:`~flowno.core.group_node.DraftGroupNode.if_`.
+
+These helpers resolve forward references correctly, so they can be used inside a
+``FlowHDL`` block just like regular node constructors.

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -7,4 +7,5 @@ Developer Guide
     :maxdepth: 2
 
     flowno_resolution_internals
+    conditional_nodes
     api_reference

--- a/docs/source/user_guide/conditional_nodes.rst
+++ b/docs/source/user_guide/conditional_nodes.rst
@@ -1,0 +1,41 @@
+.. role:: python(code)
+   :language: python
+
+****************************
+Conditional Execution
+****************************
+
+Flowno can skip parts of a flow based on runtime conditions. The helper
+:meth:`~flowno.core.node_base.DraftNode.if_` inserts a
+:class:`~flowno.core.node_base.PropagateIf` node before the current node.
+The node still resolves its inputs, but its own execution is gated by the
+predicate value.
+
+Example
+=======
+
+.. testcode::
+
+   from flowno import node, FlowHDL
+
+   @node
+   async def AddOne(x: int) -> int:
+       return x + 1
+
+   @node
+   async def IsEven(x: int) -> bool:
+       return x % 2 == 0
+
+   with FlowHDL() as f:
+       f.val = AddOne(1).if_(IsEven(2))
+
+   f.run_until_complete()
+   print(f.val.get_data())
+
+.. testoutput::
+
+   (2,)
+
+``DraftGroupNode`` provides a similar :py:meth:`~flowno.core.group_node.DraftGroupNode.if_`
+method. It wraps the entire group with ``PropagateIf`` so all internal nodes
+run but their output is gated.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -7,5 +7,6 @@ User Guide
    key_concepts
    tutorial
    groups
+   conditional_nodes
    troubleshooting
 


### PR DESCRIPTION
## Summary
- remove obsolete TODO in README
- document conditional execution with `DraftNode.if_`, `DraftGroupNode.if_`, and `PropagateIf`
- link the new docs from the user and developer guides

## Testing
- `pytest -m "not network"`

------
https://chatgpt.com/codex/tasks/task_e_6848cbf2550c8331a7963be2ef0c0411