### PR TITLE
Add IO type checking explorations

### DIFF
--- a/typecheck/io/headers_usage.py
+++ b/typecheck/io/headers_usage.py
@@ -1,0 +1,25 @@
+"""
+Exploratory type-checking tests for the ``Headers`` utility.
+
+This checks basic operations such as setting, retrieving, and iterating
+header values.
+"""
+
+from typing_extensions import assert_type
+from flowno.io import Headers
+
+
+def exercise_headers() -> None:
+    headers = Headers()
+    headers.set("Accept", ["application/json", "text/plain"])
+    headers.set("Content-Type", "application/json")
+
+    value = headers.get("accept")
+    _ = assert_type(value, str | list[str] | None)
+
+    for name, val in headers:
+        _ = assert_type(name, str)
+        _ = assert_type(val, str | list[str])
+
+    header_string = headers.stringify()
+    _ = assert_type(header_string, str)

--- a/typecheck/io/http_client_usage.py
+++ b/typecheck/io/http_client_usage.py
@@ -1,0 +1,39 @@
+"""
+Exploratory type-checking tests for the HttpClient API.
+
+This test focuses on narrowing behavior of ``streaming_response_is_ok``
+and the basic attributes of ``Response`` objects.
+"""
+
+from collections.abc import AsyncIterator
+from typing import Any
+from typing_extensions import assert_type
+
+from flowno.io import HttpClient
+from flowno.io.http_client import (
+    ErrStreamingResponse,
+    OkStreamingResponse,
+    Response,
+    streaming_response_is_ok,
+)
+
+
+async def explore_stream(client: HttpClient) -> None:
+    response = await client.stream_get("https://example.com")
+    if streaming_response_is_ok(response):
+        _ = assert_type(response, OkStreamingResponse[Any])
+        body_iter = response.body
+        _ = assert_type(body_iter, AsyncIterator[Any])
+    else:
+        _ = assert_type(response, ErrStreamingResponse)
+        body_bytes = response.body
+        _ = assert_type(body_bytes, bytes)
+
+
+async def explore_get(client: HttpClient) -> None:
+    resp = await client.get("https://example.com")
+    _ = assert_type(resp, Response)
+    code = resp.status_code
+    _ = assert_type(code, int)
+    body = resp.body
+    _ = assert_type(body, bytes)


### PR DESCRIPTION
## Summary
- add type checking tests exploring `HttpClient` and the `Headers` helper

## Testing
- `basedpyright typecheck`
- `pytest -m "not network"`

------
https://chatgpt.com/codex/tasks/task_e_6848f13cf324833195c081e6f934149b